### PR TITLE
Add headless mode to simulation-gazebo

### DIFF
--- a/simulation-gazebo
+++ b/simulation-gazebo
@@ -23,6 +23,7 @@ def main():
     parser.add_argument('--model_store', help='Path to model storage directory', required=False, default="~/.simulation-gazebo")
     parser.add_argument('--overwrite', help='Overwrite existing model directories', required=False, default=False, action='store_true')
     parser.add_argument('--dryrun', help='Test in dryrun. Do not launch gazebo', required=False, default=False, action='store_true')
+    parser.add_argument('--headless', help='Run Gazebo without GUI', required=False, default=False, action='store_true')
 
     args = parser.parse_args()
 
@@ -89,7 +90,10 @@ def main():
     # Launch gazebo simulation
     print('> Launching gazebo simulation...')
     if not args.dryrun:
-        cmd = f'GZ_SIM_RESOURCE_PATH={args.model_store}/models gz sim -r {args.model_store}/worlds/{args.world}.sdf'
+        if args.headless:
+            cmd = f'GZ_SIM_RESOURCE_PATH={args.model_store}/models gz sim -s -r {args.model_store}/worlds/{args.world}.sdf'
+        else:
+            cmd = f'GZ_SIM_RESOURCE_PATH={args.model_store}/models gz sim -r {args.model_store}/worlds/{args.world}.sdf'
 
         if args.gz_partition:
             cmd = f'GZ_PARTITION={args.gz_partition} {cmd}'


### PR DESCRIPTION
`-s` and `-g` flags can be used to run gazebo server and GUI separately. `--headless` flag to python script adds ability to trigger `-s` behavior from the CLI.